### PR TITLE
Use DEFPARAMTER instead of DEFINE-CONSTANT

### DIFF
--- a/colors.lisp
+++ b/colors.lisp
@@ -156,6 +156,6 @@ combination is in the positive or negative direction on the color wheel."
 the automatically generated color file."
   (let ((constant-name (symbolicate #\+ name #\+)))
     `(progn
-       (define-constant ,constant-name (rgb ,red ,green ,blue)
-         :test #'equalp :documentation ,(format nil "X11 color ~A." name))
+       (defparameter ,constant-name (rgb ,red ,green ,blue)
+         ,(format nil "X11 color ~A." name))
        (export ',constant-name))))


### PR DESCRIPTION
Due to the way #S works in compiled code, using `define-constant` fails in some lisp implementations, e.g., CCL, in most cases.  For instance, the following will error if you try and compile/load in CCL:

``` lisp
(defun foo () cl-colors:+red+)

(defclass ink () ((color :initform cl-colors:+black+)))
```

Changing this to `DEFPARAMETER` (as per @jasom's suggestion) causes the Lisp to not store the literal, therefore bypasses the issue.

In theory, one could also implement `MAKE-LOAD-FORM`, but doing things in this manner doesn't gain much besides the `EQUALP` check; the struct must still be constructed at load.  Arguably, these shouldn't be constants per se, because they're symbolic names for colors, and hypothetically the values could be tweaked if errors are found / the standard is updated, and thus changing them doesn't seem like an error.
